### PR TITLE
use CloudFromt url in tests  for dev, stage, prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+baseUrl=https://*****
+restaurants_api=https://****/restaurants
+cognito_user_pool_id=us-east-1_*****
+cognito_client_id=*****
+restaurants_table=workshop-murat-dev-RestaurantsTable-****

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,18 @@
 const {defineConfig} = require('cypress')
 require('dotenv').config()
 
+/**
+ * Use CloudFront for dev and stage, otherwise (for temp branches) use baseUrl
+ */
+const getBaseUrl = () => {
+  const {deployment, baseUrl, CLOUDFRONT_URL} = process.env
+  const url =
+    deployment === 'dev' || deployment === 'stage' || deployment === 'prod'
+      ? `${CLOUDFRONT_URL}/${deployment}`
+      : baseUrl
+  return url
+}
+
 module.exports = defineConfig({
   projectId: '69umec',
   viewportWidth: 1380,
@@ -10,7 +22,7 @@ module.exports = defineConfig({
     ...process.env,
   },
   e2e: {
-    baseUrl: process.env.baseUrl,
+    baseUrl: getBaseUrl(),
     setupNodeEvents(on, config) {
       return config
     },

--- a/serverless.yml
+++ b/serverless.yml
@@ -30,6 +30,8 @@ provider:
           Resource: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGatewayRestApi}/${sls:stage}/GET/restaurants
   environment:
     baseUrl: !Sub https://${ApiGatewayRestApi}.execute-api.${AWS::Region}.amazonaws.com/${sls:stage}
+    deployment: ${sls:stage}
+    CLOUDFRONT_URL: 'https://d27lew3mfrizo7.cloudfront.net'
 
 plugins:
   # exports the environment variables to a **.env** file.


### PR DESCRIPTION
for temporary branches, still uses the api gateway url