### PR TITLE
fix optic workflow

### DIFF
--- a/optic.yml
+++ b/optic.yml
@@ -21,4 +21,4 @@ capture:
         command: npm run test:e2e
         # The name of the environment variable injected into the env of the command that contains the address of the Optic proxy.
         # Optional: default: OPTIC_PROXY
-        proxy_variable: baseUrl
+        proxy_variable: rest_api_url

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "cy:run-fast": "cypress run --e2e --browser chrome --config video=false screenshot=false",
     "typecheck": "tsc --noEmit",
     "create:openapi": "./create-openapi.sh",
-    "optic:verify": "dotenv -e .env optic capture openapi.yml --server-override $baseUrl interactive",
-    "optic:update": "dotenv -e .env optic capture openapi.yml --server-override $baseUrl --update interactive"
+    "optic:verify": "$(cat .env | grep 'baseUrl' | xargs) optic capture openapi.yml --server-override $baseUrl interactive",
+    "optic:update": "$(cat .env | grep 'baseUrl' | xargs) optic capture openapi.yml --server-override $baseUrl --update interactive"
   },
   "devDependencies": {
     "@aws-sdk/client-cognito-identity-provider": "3.369.0",


### PR DESCRIPTION
sets the baseUrl to read from the env variable and sets the optic proxy variable to reexport to `rest_api_url`